### PR TITLE
3 - implementation of join session page

### DIFF
--- a/poker-fe/src/App.jsx
+++ b/poker-fe/src/App.jsx
@@ -4,6 +4,7 @@ import store from "store/index";
 import { createBrowserHistory } from "history";
 import { Router, Switch, Route } from "react-router-dom";
 import SessionSelection from "pages/SessionSelection";
+import JoinSession from "pages/JoinSession";
 import "./App.css";
 
 const hist = createBrowserHistory();
@@ -14,7 +15,8 @@ function App() {
     <Provider store={store}>
       <Router history={hist}>
         <Switch>
-          <Route path='/' component={SessionSelection} />
+          <Route path="/join-session" component={JoinSession} />
+          <Route path="/" component={SessionSelection} />
         </Switch>
       </Router>
     </Provider>

--- a/poker-fe/src/components/JoinSession/Form.jsx
+++ b/poker-fe/src/components/JoinSession/Form.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Card, Button, Form } from "react-bootstrap";
+
+const JoinSessionForm = () => {
+  return (
+    <Card className="text-center ">
+      <Card.Header as="h5">Join Session</Card.Header>
+      <Card.Body>
+        <Form>
+          <Form.Group controlId="formBasicEmail">
+            <Form.Label>Your Name</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Enter your name"
+              className="text-center"
+            />
+          </Form.Group>
+          <Button variant="primary" type="submit">
+            Join
+          </Button>
+        </Form>
+      </Card.Body>
+    </Card>
+  );
+};
+export default JoinSessionForm;

--- a/poker-fe/src/pages/JoinSession/index.jsx
+++ b/poker-fe/src/pages/JoinSession/index.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Container, Row, Col, Navbar } from "react-bootstrap";
+import JoinSessionForm from "components/JoinSession/Form";
+
+const JoinSession = () => {
+  return (
+    <>
+      <Navbar bg="dark" expand="lg">
+        <Navbar.Brand href="/" className="text-light">
+          Planning Poker
+        </Navbar.Brand>
+        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+      </Navbar>
+      <Container className="h-100">
+        <Row className="align-items-center h-100 mt-5">
+          <Col sm="6" className="mx-auto">
+            <JoinSessionForm />
+          </Col>
+        </Row>
+      </Container>
+    </>
+  );
+};
+
+export default JoinSession;


### PR DESCRIPTION
In this PR, we have created the JOIN SESSION by using the [form elements of react-bootstrap](https://react-bootstrap.github.io/components/forms/). 

To create the page for this feature, we have created a page ```JoinSession``` as we already created for ```SessionSelection``` with relevant layout and have also created its feature section in ```components/JoinSession``` directory.

As we already know that creation of ```pages type component``` is not enough to access the implemented page and we have to assign URL to our ```pages```.  So to assign the URL to our page, we have added a route with URL```/join-session``` & assign that to ```JoinSession``` page in ```App.jsx``` which contains the complete logic of our routing.

If you are running the app on local then you are able to access the JoinSession UI through the below URL

[http://localhost:3000/join-session](http://localhost:3000/join-session)


![3-joinSesson](https://user-images.githubusercontent.com/1968160/79049267-0f9c3980-7c3c-11ea-89f7-e171172239e7.png)
