### PR TITLE
4 - Adding  layouts for pages

### DIFF
--- a/poker-fe/src/App.jsx
+++ b/poker-fe/src/App.jsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import store from "store/index";
 import { createBrowserHistory } from "history";
 import { Router, Switch, Route } from "react-router-dom";
+import DefaultLayout from "layouts/DefaultLayout";
 import SessionSelection from "pages/SessionSelection";
 import JoinSession from "pages/JoinSession";
 import "./App.css";
@@ -15,8 +16,8 @@ function App() {
     <Provider store={store}>
       <Router history={hist}>
         <Switch>
-          <Route path="/join-session" component={JoinSession} />
-          <Route path="/" component={SessionSelection} />
+          <Route path='/join-session' component={DefaultLayout(JoinSession)} />
+          <Route path='/' component={DefaultLayout(SessionSelection)} />
         </Switch>
       </Router>
     </Provider>

--- a/poker-fe/src/layouts/DefaultLayout.jsx
+++ b/poker-fe/src/layouts/DefaultLayout.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Container, Navbar } from "react-bootstrap";
+
+const DefaultLayout = (PokerComponent) => {
+  return (props) => (
+    <>
+      <Navbar bg='dark' expand='lg'>
+        <Navbar.Brand href='/' className='text-light'>
+          Planning Poker
+        </Navbar.Brand>
+        <Navbar.Toggle aria-controls='basic-navbar-nav' />
+      </Navbar>
+      <Container className='h-100'>
+        <PokerComponent {...props} />
+      </Container>
+    </>
+  );
+};
+
+export default DefaultLayout;

--- a/poker-fe/src/pages/JoinSession/index.jsx
+++ b/poker-fe/src/pages/JoinSession/index.jsx
@@ -1,24 +1,14 @@
 import React from "react";
-import { Container, Row, Col, Navbar } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 import JoinSessionForm from "components/JoinSession/Form";
 
 const JoinSession = () => {
   return (
-    <>
-      <Navbar bg="dark" expand="lg">
-        <Navbar.Brand href="/" className="text-light">
-          Planning Poker
-        </Navbar.Brand>
-        <Navbar.Toggle aria-controls="basic-navbar-nav" />
-      </Navbar>
-      <Container className="h-100">
-        <Row className="align-items-center h-100 mt-5">
-          <Col sm="6" className="mx-auto">
-            <JoinSessionForm />
-          </Col>
-        </Row>
-      </Container>
-    </>
+    <Row className='align-items-center h-100 mt-5'>
+      <Col sm='6' className='mx-auto'>
+        <JoinSessionForm />
+      </Col>
+    </Row>
   );
 };
 

--- a/poker-fe/src/pages/SessionSelection/index.jsx
+++ b/poker-fe/src/pages/SessionSelection/index.jsx
@@ -1,28 +1,18 @@
 import React from "react";
-import { Container, Row, Col, Navbar } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 import JoinSessionCard from "components/SessionSelection/JoinSession";
 import CreateSessionCard from "components/SessionSelection/CreateSession";
 
 const SessionSelection = () => {
   return (
-    <>
-      <Navbar bg='dark' expand='lg'>
-        <Navbar.Brand href='/' className='text-light'>
-          Planning Poker
-        </Navbar.Brand>
-        <Navbar.Toggle aria-controls='basic-navbar-nav' />
-      </Navbar>
-      <Container className='h-100'>
-        <Row className='align-items-center h-100 mt-5'>
-          <Col sm='6'>
-            <CreateSessionCard />
-          </Col>
-          <Col sm='6 '>
-            <JoinSessionCard />
-          </Col>
-        </Row>
-      </Container>
-    </>
+    <Row className='align-items-center h-100 mt-5'>
+      <Col sm='6'>
+        <CreateSessionCard />
+      </Col>
+      <Col sm='6 '>
+        <JoinSessionCard />
+      </Col>
+    </Row>
   );
 };
 


### PR DESCRIPTION
The application code should always be clean and no logic should be repetitive in whole code. Unfortunately, we have the header code which is repeating in both pages ```SelectSession``` & ```JoinSession```. 

So to keep the code reusable, we have created layouts by using higher order component and incorporated the page layout in that. [HigherOrderComponent](https://reactjs.org/docs/higher-order-components.html) is basically the functions which returns  the component.

The HOC can be used with the component through 2 ways in our application:

1 - We can use it by wrapping the component while exporting it, like in ```JoinSession/index.js``` we can use it like this

```export default DefaultLayout(JoinSession)```

2 - The other option is to use while passing the component to route. and this is the best way to utilize the layout with pages because we can reuse the same page with different layout with different URL.