### PR TITLE
5 - Create session page

### DIFF
--- a/poker-fe/src/App.jsx
+++ b/poker-fe/src/App.jsx
@@ -6,6 +6,7 @@ import { Router, Switch, Route } from "react-router-dom";
 import DefaultLayout from "layouts/DefaultLayout";
 import SessionSelection from "pages/SessionSelection";
 import JoinSession from "pages/JoinSession";
+import CreateSession from "pages/CreateSession";
 import "./App.css";
 
 const hist = createBrowserHistory();
@@ -16,6 +17,10 @@ function App() {
     <Provider store={store}>
       <Router history={hist}>
         <Switch>
+          <Route
+            path='/create-session'
+            component={DefaultLayout(CreateSession)}
+          />
           <Route path='/join-session' component={DefaultLayout(JoinSession)} />
           <Route path='/' component={DefaultLayout(SessionSelection)} />
         </Switch>

--- a/poker-fe/src/components/CreateSession/Form.jsx
+++ b/poker-fe/src/components/CreateSession/Form.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Card, Button, Form } from "react-bootstrap";
+
+const CreateSessionForm = () => {
+  return (
+    <Card className='text-center '>
+      <Card.Header as='h5'>Start New Session</Card.Header>
+      <Card.Body>
+        <Form>
+          <Form.Group controlId='formBasicEmail'>
+            <Form.Label>Session Name</Form.Label>
+            <Form.Control
+              type='text'
+              name='sessionName'
+              placeholder='Enter Session name'
+              className='text-center'
+            />
+          </Form.Group>
+          <Form.Group controlId='formBasicEmail'>
+            <Form.Label>Your Name</Form.Label>
+            <Form.Control
+              type='text'
+              name='userName'
+              placeholder='Enter your name'
+              className='text-center'
+            />
+          </Form.Group>
+          <Button variant='primary' type='submit'>
+            Join
+          </Button>
+        </Form>
+      </Card.Body>
+    </Card>
+  );
+};
+export default CreateSessionForm;

--- a/poker-fe/src/pages/CreateSession/index.jsx
+++ b/poker-fe/src/pages/CreateSession/index.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Row, Col } from "react-bootstrap";
+import CreateSessionForm from "components/CreateSession/Form";
+
+const CreateSession = () => {
+  return (
+    <Row className='align-items-center h-100 mt-5'>
+      <Col sm='6' className='mx-auto'>
+        <CreateSessionForm />
+      </Col>
+    </Row>
+  );
+};
+
+export default CreateSession;


### PR DESCRIPTION
As we have created the join session page, now we are creating the ```Create Session``` page through which user will be able to create a new session.

In this PR, we have implemented the form of ```CreateSession``` and a page of ```CreateSession``` with its required layout. And incorporated the form in page in its required grid location. 

To access this page, we have added a router ```create-session/``` in App.jsx.

On local, the page is accessible through the following URL

[http://localhost:3000/create-session](http://localhost:3000/create-session)

![5-create-sesssion](https://user-images.githubusercontent.com/1968160/79053379-6151bd80-7c56-11ea-90f5-014752a64276.png)

