### PR TITLE
18 - SessionTypes seeder

### DIFF
--- a/poker-be/seeders/20200418102321-sessionTypes.js
+++ b/poker-be/seeders/20200418102321-sessionTypes.js
@@ -1,0 +1,43 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkInsert('People', [{
+        name: 'John Doe',
+        isBetaMember: false
+      }], {});
+    */
+    return queryInterface.bulkInsert(
+      "SessionTypes",
+      [
+        {
+          title: "Fibonacci",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          title: "t-shirts",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+    return queryInterface.bulkDelete("SessionTypes", null, {});
+  },
+};


### PR DESCRIPTION
When developing databases with it a team, it can be important that everyone is working with the same data. Or you might have information that you want to enter in your database initally, like admin accounts or something like that. You can do this with Seeders.

Using sequelize-cli you can easily create and manage your seed files. It has a useful command called seed:create, which will generate 2 files for you: a seed .

It has a couple handy options so that you can create your schemas from the command line:

```
$ sequelize seed:create --name sessionTypes
```

Running this command will result in a file in your seeders directory with code in file 
``poker-be/seeders/20200418102321-sessionTypes.js``

Add the seeder data in seeder file and after that run the below command to migrate the data in database

```
$ sequelize db:seed:all
```

